### PR TITLE
Nightly build page improvements

### DIFF
--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -8,10 +8,13 @@ nightly-repo: pencil2d/pencil
 nightly-workflow: ci.yml
 drive-api-key: AIzaSyD2z_aPwUD5HFRHUtFKihgoEWv3nZnzsik
 windows-x86-parent: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E
+windows-x86-resource-key: 0-7hr0hkLkSBVdEkaeb-okdg
 windows-x86-64-parent: 0BxdcdOiOmg-CSVlqc3JNQV9hVGs
+windows-x86-64-resource-key: 0-mfeDpkYVm70KrOvKYM7UVw
 macos-parent: 0BxdcdOiOmg-CeVpTY294cXdLZ2c
+macos-resource-key: 0-OH02kleYDbtzlw3UbxFMZA
 linux-parent: 0BxdcdOiOmg-CcU1WOFpCOFBvVXc
-resource-keys: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E/0-7hr0hkLkSBVdEkaeb-okdg,0BxdcdOiOmg-CSVlqc3JNQV9hVGs/0-mfeDpkYVm70KrOvKYM7UVw,0BxdcdOiOmg-CeVpTY294cXdLZ2c/0-OH02kleYDbtzlw3UbxFMZA,0BxdcdOiOmg-CcU1WOFpCOFBvVXc/0-2L-INjRPsn2ANX4MZIGU0Q
+linux-resource-key: 0-2L-INjRPsn2ANX4MZIGU0Q
 ---
 
 Nightly Builds are created automatically whenever the Pencil2D source code is updated and are therefore the most
@@ -50,7 +53,7 @@ a certain build is not available for your operating system, please check the pre
 </style>
 
 <noscript id="build-dirs">
-<h2>Build Directories</h2>
+<h2>Nightly Build Directories</h2>
 <p>The following links will direct you to Google Drive folders. Please right-click on a file listed and select <code>Download</code>. The naming format is <code>pencil2d-OS-buildnumber-year-month-day</code>.</p>
 
 <table>
@@ -75,23 +78,36 @@ a certain build is not available for your operating system, please check the pre
 
 <ol id="nightly-builds"></ol>
 
+<script src="nightly_fetch.js"></script>
 <script>
   "use strict";
   (function() {
-    function fetchGoogleDriveFiles(parentId) {
-      return fetch(`https://content.googleapis.com/drive/v3/files?q=%22${parentId}%22%20in%20parents&fields=files(originalFilename,webContentLink)&pageSize={{page.fetch-limit}}&key={{page.drive-api-key}}`, {
-        headers: {
-          "X-Goog-Drive-Resource-Keys": "{{page.resource-keys}}"
-        }
-      })
-    }
+    let hasFallenBack = false;
+    function displayFallback() {
+      if (hasFallenBack) return;
 
-    function showError() {
       const nightlyLoading = document.getElementById("nightly-loading");
-      nightlyLoading.textContent = "Unable to retrieve Nightly Builds. Please try again later.";
+      nightlyLoading.style.display = "none";
       const buildDirs = document.createElement("div");
       buildDirs.innerHTML = document.getElementById("build-dirs").innerHTML;
-      nightlyLoading.parentNode.insertBefore(buildDirs, nightlyLoading);
+      nightlyLoading.parentNode.append(buildDirs);
+      hasFallenBack = true;
+    }
+
+    function showError(message) {
+      displayFallback();
+      const nightlyLoading = document.getElementById("nightly-loading");
+      const errorMessage = document.createElement("blockquote");
+      errorMessage.textContent = message;
+      nightlyLoading.parentNode.insertBefore(errorMessage, nightlyLoading.nextSibling);
+    }
+
+    function showWarning(message) {
+      displayFallback();
+      const nightlyLoading = document.getElementById("nightly-loading");
+      const warningMessage = document.createElement("blockquote");
+      warningMessage.textContent = message;
+      nightlyLoading.parentNode.insertBefore(warningMessage, nightlyLoading.nextSibling);
     }
 
     // Add loading message
@@ -103,122 +119,129 @@ a certain build is not available for your operating system, please check the pre
       nightlyBuilds.parentNode.insertBefore(nightlyLoading, nightlyBuilds);
     }
 
-    Promise.all([
-      // Fetch workflow runs
-      fetch("https://api.github.com/repos/{{page.nightly-repo}}/actions/workflows/{{page.nightly-workflow}}/runs?per_page={{page.fetch-limit}}", {
-        headers: {
-          "Accept": "application/vnd.github.v3+json"
-        }
-      }).then(response => response.json()),
+    const fetcher = new NightlyBuildFetcher("{{page.drive-api-key}}", {{page.fetch-limit}});
+    fetcher.addGithubActionsResource("{{page.nightly-repo}}", "{{page.nightly-workflow}}", "runs");
+    fetcher.addGDriveResource("{{page.windows-x86-parent}}", "{{page.windows-x86-resource-key}}", "win32");
+    fetcher.addGDriveResource("{{page.windows-x86-64-parent}}", "{{page.windows-x86-64-resource-key}}", "win64");
+    fetcher.addGDriveResource("{{page.macos-parent}}", "{{page.macos-resource-key}}", "macos");
+    fetcher.addGDriveResource("{{page.linux-parent}}", "{{page.linux-resource-key}}", "linux");
 
-      // ...and files for all OSes on Google Drive
-      fetchGoogleDriveFiles("{{page.windows-x86-parent}}").then(response => response.json()),
-      fetchGoogleDriveFiles("{{page.windows-x86-64-parent}}").then(response => response.json()),
-      fetchGoogleDriveFiles("{{page.macos-parent}}").then(response => response.json()),
-      fetchGoogleDriveFiles("{{page.linux-parent}}").then(response => response.json())
-    ]).then(([runs, win32Files, win64Files, macosFiles, linuxFiles]) => {
-      if ("message" in runs ||
-          "message" in win32Files ||
-          "message" in win64Files ||
-          "message" in macosFiles ||
-          "message" in linuxFiles) {
-        // Messages are bad news, it means we got an error
-        showError();
+    fetcher.fetchAll().then(fetch_results => {
+      if (Object.keys(fetch_results).length <= 1) {
+        showError("There was an error automatically retrieving the nightly build data.");
         return;
       }
+      if ("runs" in fetch_results) {
+        const aggregatedData = {};
 
-      const aggregatedData = {};
-
-      // Collect all the per-OS download links for each run
-      for (let [os, folder] of [["win32", win32Files], ["win64", win64Files], ["macos", macosFiles], ["linux", linuxFiles]]) {
-        for (let file of folder.files) {
-          const match = file.originalFilename.match(/^pencil2d-\w+-(\d+)-\d{4}-\d{2}-\d{2}.(zip|AppImage)$/);
-          if (match === null) {
-            // File name didn't match, don't know what to do with it
+        // Collect all the per-OS download links for each run
+        for (let os of ["win32", "win64", "macos", "linux"]) {
+          if (!(os in fetch_results)) {
+            showWarning(`Warning: Could not get data for ${os}`);
             continue;
           }
-          const runNumber = match[1];
-          if (runNumber in aggregatedData === false) {
-            aggregatedData[runNumber] = {};
+          const folder = fetch_results[os];
+
+          for (let file of folder.files) {
+            const match = file.originalFilename.match(/^pencil2d-\w+-(\d+)-\d{4}-\d{2}-\d{2}.(zip|AppImage)$/);
+            if (match === null) {
+              // File name didn't match, don't know what to do with it
+              continue;
+            }
+            const runNumber = match[1];
+            if (runNumber in aggregatedData === false) {
+              aggregatedData[runNumber] = {};
+            }
+            aggregatedData[runNumber][os] = file.webContentLink;
           }
-          aggregatedData[runNumber][os] = file.webContentLink;
         }
-      }
 
-      // Add the metadata for all the runs that we have files for
-      for (let run of runs.workflow_runs) {
-        if (run.run_number in aggregatedData) {
-          aggregatedData[run.run_number]["commit"] = run.head_commit
-          aggregatedData[run.run_number]["run_url"] = run.html_url
+        // Add the metadata for all the runs that we have files for
+        for (let run of fetch_results["runs"].workflow_runs) {
+          if (run.run_number in aggregatedData) {
+            aggregatedData[run.run_number]["commit"] = run.head_commit
+            aggregatedData[run.run_number]["run_url"] = run.html_url
+          }
         }
-      }
 
-      // Let's "render" our data
-      const nightlyList = document.getElementById("nightly-builds");
-      let detailsOpen = true;
-      for (let [runNumber, data] of Object.entries(aggregatedData).sort((a, b) => Math.sign(b[0] - a[0]))) {
-        const buildItem = document.createElement("li");
-        buildItem.value = runNumber;
-        const details = document.createElement("details");
-        // Open the first entry by default
-        details.open = detailsOpen;
-        detailsOpen = false;
-        const summary = document.createElement("summary");
-        if ("commit" in data) {
-          // Build summary - timestamp + (linked) commit message
-          const timestamp = new Date(data.commit.timestamp);
-          const dateMessage = document.createElement("span")
-          dateMessage.textContent = timestamp.toLocaleString(undefined, {"dateStyle": "medium"}) + " \u2013 ";
-          dateMessage.title = timestamp.toLocaleString(undefined, {"dateStyle": "long", "timeStyle": "long"});
-          summary.appendChild(dateMessage);
-          const commitLink = document.createElement("a");
-          commitLink.appendChild(document.createTextNode(data.commit.message.split("\n")[0]));
-          commitLink.href = `https://github.com/{{page.nightly-repo}}/commit/${data.commit.id}`;
-          summary.appendChild(commitLink);
-        } else {
-          // Got no metadata about this run :(
-          summary.appendChild(document.createTextNode("Unable to retrieve information"));
-        }
-        details.appendChild(summary);
+        // Let's "render" our data
+        const nightlyList = document.getElementById("nightly-builds");
 
-        // Add the actual details area...
-        const linkList = document.createElement("ul");
+        const nightlyListTitle = document.createElement("h2");
+        nightlyListTitle.textContent = "Nightly Build List";
+        nightlyList.parentNode.insertBefore(nightlyListTitle, nightlyList);
 
-        // ...with the download links...
-        const downloadList = document.createElement("li");
-        let text = "Download for ";
-        for (let [os, osName] of [["win32", "Windows (32-bit)"], ["win64", "Windows (64-bit)"], ["macos", "macOS"], ["linux", "Linux (64-bit)"]]) {
-          if (os in data === false) {
-            continue; // No download for this OS
+        let detailsOpen = true;
+        for (let [runNumber, data] of Object.entries(aggregatedData).sort((a, b) => Math.sign(b[0] - a[0]))) {
+          const buildItem = document.createElement("li");
+          buildItem.value = runNumber;
+          const details = document.createElement("details");
+          // Open the first entry by default
+          details.open = detailsOpen;
+          detailsOpen = false;
+          const summary = document.createElement("summary");
+          if ("commit" in data) {
+            // Build summary - timestamp + (linked) commit message
+            const timestamp = new Date(data.commit.timestamp);
+            const dateMessage = document.createElement("span")
+            dateMessage.textContent = timestamp.toLocaleString(undefined, {"dateStyle": "medium"}) + " \u2013 ";
+            dateMessage.title = timestamp.toLocaleString(undefined, {"dateStyle": "long", "timeStyle": "long"});
+            summary.appendChild(dateMessage);
+            const commitLink = document.createElement("a");
+            commitLink.appendChild(document.createTextNode(data.commit.message.split("\n")[0]));
+            commitLink.href = `https://github.com/{{page.nightly-repo}}/commit/${data.commit.id}`;
+            summary.appendChild(commitLink);
+          } else {
+            // Got no metadata about this run :(
+            summary.appendChild(document.createTextNode("Unable to retrieve information"));
+          }
+          details.appendChild(summary);
+
+          // Add the actual details area...
+          const linkList = document.createElement("ul");
+
+          // ...with the download links...
+          const downloadList = document.createElement("li");
+          let text = "Download for ";
+          for (let [os, osName] of [["win32", "Windows (32-bit)"], ["win64", "Windows (64-bit)"], ["macos", "macOS"], ["linux", "Linux (64-bit)"]]) {
+            if (os in data === false) {
+              continue; // No download for this OS
+            }
+
+            downloadList.appendChild(document.createTextNode(text));
+            text = ' \u2022 '; // bullet
+            const downloadLink = document.createElement("a");
+            downloadLink.appendChild(document.createTextNode(osName));
+            downloadLink.href = data[os];
+            downloadList.appendChild(downloadLink);
+          }
+          linkList.appendChild(downloadList);
+
+          // ...and the link to the build details
+          if ("run_url" in data) {
+            const buildDetails = document.createElement("li");
+            buildDetails.appendChild(document.createTextNode("View "));
+            const detailsLink = document.createElement("a");
+            detailsLink.appendChild(document.createTextNode("build details"));
+            detailsLink.href = data.run_url;
+            buildDetails.appendChild(detailsLink);
+            linkList.appendChild(buildDetails);
           }
 
-          downloadList.appendChild(document.createTextNode(text));
-          text = ' \u2022 '; // bullet
-          const downloadLink = document.createElement("a");
-          downloadLink.appendChild(document.createTextNode(osName));
-          downloadLink.href = data[os];
-          downloadList.appendChild(downloadLink);
+          details.appendChild(linkList);
+          buildItem.appendChild(details);
+          nightlyList.appendChild(buildItem);
         }
-        linkList.appendChild(downloadList);
-
-        // ...and the link to the build details
-        if ("run_url" in data) {
-          const buildDetails = document.createElement("li");
-          buildDetails.appendChild(document.createTextNode("View "));
-          const detailsLink = document.createElement("a");
-          detailsLink.appendChild(document.createTextNode("build details"));
-          detailsLink.href = data.run_url;
-          buildDetails.appendChild(detailsLink);
-          linkList.appendChild(buildDetails);
-        }
-
-        details.appendChild(linkList);
-        buildItem.appendChild(details);
-        nightlyList.appendChild(buildItem);
+        // Remove the loading message
+        document.getElementById("nightly-loading").remove();
       }
-      // Remove the loading message
-      document.getElementById("nightly-loading").remove();
-    })
-    .catch(showError);
+      else {
+        showError("There was an error automatically fetching the build data.");
+        return;
+      }
+    }).catch(error => {
+      console.error(error);
+      showError("There was an error automatically fetching the build data.");
+    });
   })();
 </script>

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -75,9 +75,6 @@ The following links will direct you to Google Drive folders. Please right-click 
 </div>
 </noscript>
 
-> Loading...
-{:#nightly-loading}
-
 <ol id="nightly-builds"></ol>
 
 <script>
@@ -96,6 +93,14 @@ The following links will direct you to Google Drive folders. Please right-click 
       nightlyLoading.textContent = "Unable to retrieve Nightly Builds. Please try again later.";
       const buildDirs = document.getElementById("build-dirs");
       nightlyLoading.appendChild(buildDirs);
+    }
+    
+    // Add loading message
+    {
+      const nightlyBuilds = document.getElementById("nightly-builds");
+      const nightlyLoading = document.createElement("blockquote");
+      nightlyLoading.appendChild(document.createTextNode("Loading\u2026"));
+      nightlyBuilds.parentNode.insertBefore(nightlyLoading, nightlyBuilds);
     }
 
     Promise.all([

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -127,7 +127,10 @@ a certain build is not available for your operating system, please check the pre
         const summary = document.createElement("summary");
         if ("commit" in data) {
           // Build summary - timestamp + (linked) commit message
-          summary.appendChild(document.createTextNode(`${data.commit.timestamp.replace("T", "_").replace("Z", "")} \u2013 `));
+          const timestamp = new Date(data.commit.timestamp);
+          const dateMessage = document.createTextNode(timestamp.toLocaleString(undefined, {"dateStyle": "medium"}) + " \u2013 ");
+          dateMessage.title = timestamp.toLocaleString(undefined, {"dateStyle": "long", "timeStyle": "long"});
+          summary.appendChild(dateMessage);
           const commitLink = document.createElement("a");
 
           let commitMessage = data.commit.message.split("\n").shift();

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -67,10 +67,10 @@ a certain build is not available for your operating system, please check the pre
   </thead>
   <tbody>
     <tr>
-      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CSVlqc3JNQV9hVGs?resourcekey=0-mfeDpkYVm70KrOvKYM7UVw&usp=sharing">Download</a></td>
-      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CcUEwS1R0WFhwM0E?resourcekey=0-7hr0hkLkSBVdEkaeb-okdg&usp=sharing">Download</a></td>
-      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CeVpTY294cXdLZ2c?resourcekey=0-OH02kleYDbtzlw3UbxFMZA&usp=sharing">Download</a></td>
-      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CcU1WOFpCOFBvVXc?resourcekey=0-2L-INjRPsn2ANX4MZIGU0Q&usp=sharing">Download</a></td>
+    <td style="text-align: center"><a href="https://drive.google.com/drive/folders/{{page.windows-x86-64-parent}}?resourcekey={{page.windows-x86-64-resource-key}}&usp=sharing">Download</a></td>
+    <td style="text-align: center"><a href="https://drive.google.com/drive/folders/{{page.windows-x86-parent}}?resourcekey={{page.windows-x86-64-resource-key}}&usp=sharing">Download</a></td>
+    <td style="text-align: center"><a href="https://drive.google.com/drive/folders/{{page.macos-parent}}?resourcekey={{page.macos-resource-key}}&usp=sharing">Download</a></td>
+    <td style="text-align: center"><a href="https://drive.google.com/drive/folders/{{page.linux-parent}}?resourcekey={{page.linux-resource-key}}&usp=sharing">Download</a></td>
     </tr>
   </tbody>
 </table>

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -39,11 +39,15 @@ a certain build is not available for your operating system, please check the pre
 #nightly-builds summary {
   cursor: pointer;
   display: list-item;
+  width: 100%;
+}
+
+#nightly-builds details:not([open]) summary {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 100%;
 }
+
 #nightly-builds ul {
   padding-left: 2em;
 }

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -5,7 +5,6 @@ tagline: Download bleeding edge builds of Pencil2D
 comments: false
 fetch-limit: 100
 nightly-repo: pencil2d/pencil
-nightly-branch: master
 nightly-workflow: ci.yml
 drive-api-key: AIzaSyD2z_aPwUD5HFRHUtFKihgoEWv3nZnzsik
 windows-x86-parent: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E
@@ -67,7 +66,7 @@ a certain build is not available for your operating system, please check the pre
 
     Promise.all([
       // Fetch workflow runs
-      fetch("https://api.github.com/repos/{{page.nightly-repo}}/actions/workflows/{{page.nightly-workflow}}/runs?branch={{page.nightly-branch}}&per_page={{page.fetch-limit}}", {
+      fetch("https://api.github.com/repos/{{page.nightly-repo}}/actions/workflows/{{page.nightly-workflow}}/runs?per_page={{page.fetch-limit}}", {
         headers: {
           "Accept": "application/vnd.github.v3+json"
         }

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -49,8 +49,7 @@ a certain build is not available for your operating system, please check the pre
 }
 </style>
 
-<noscript>
-<div id="build-dirs">
+<noscript id="build-dirs">
 <h2>Build Directories</h2>
 The following links will direct you to Google Drive folders. Please right-click on a file listed and select <code>Download</code>. The naming format is <code>pencil2d-OS-buildnumber-year-month-day</code>.
 
@@ -72,7 +71,6 @@ The following links will direct you to Google Drive folders. Please right-click 
     </tr>
   </tbody>
 </table>
-</div>
 </noscript>
 
 <ol id="nightly-builds"></ol>
@@ -91,8 +89,9 @@ The following links will direct you to Google Drive folders. Please right-click 
     function showError() {
       const nightlyLoading = document.getElementById("nightly-loading");
       nightlyLoading.textContent = "Unable to retrieve Nightly Builds. Please try again later.";
-      const buildDirs = document.getElementById("build-dirs");
-      nightlyLoading.appendChild(buildDirs);
+      const buildDirs = document.createElement("div");
+      buildDirs.innerHTML = document.getElementById("build-dirs").innerHTML;
+      nightlyLoading.parentNode.insertBefore(buildDirs, nightlyLoading);
     }
     
     // Add loading message

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -36,6 +36,10 @@ a certain build is not available for your operating system, please check the pre
 #nightly-builds summary {
   cursor: pointer;
   display: list-item;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
 }
 #nightly-builds ul {
   padding-left: 2em;
@@ -132,14 +136,7 @@ a certain build is not available for your operating system, please check the pre
           dateMessage.title = timestamp.toLocaleString(undefined, {"dateStyle": "long", "timeStyle": "long"});
           summary.appendChild(dateMessage);
           const commitLink = document.createElement("a");
-
-          let commitMessage = data.commit.message.split("\n").shift();
-          if (commitMessage.length > 72) {
-            // Make sure commit message is no longer than 72 characters (like GitHub)
-            commitMessage = commitMessage.substring(0, 69) + "...";
-          }
-
-          commitLink.appendChild(document.createTextNode(commitMessage));
+          commitLink.appendChild(document.createTextNode(data.commit.message.split("\n")[0]));
           commitLink.href = `https://github.com/{{page.nightly-repo}}/commit/${data.commit.id}`;
           summary.appendChild(commitLink);
         } else {

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -188,8 +188,8 @@ a certain build is not available for your operating system, please check the pre
             // Build summary - timestamp + (linked) commit message
             const timestamp = new Date(data.commit.timestamp);
             const dateMessage = document.createElement("span")
-            dateMessage.textContent = timestamp.toLocaleString(undefined, {"dateStyle": "medium"}) + " \u2013 ";
-            dateMessage.title = timestamp.toLocaleString(undefined, {"dateStyle": "long", "timeStyle": "long"});
+            dateMessage.textContent = timestamp.toLocaleString("en-US", {"dateStyle": "medium"}) + " \u2013 ";
+            dateMessage.title = timestamp.toLocaleString("en-US", {"dateStyle": "long", "timeStyle": "long"});
             summary.appendChild(dateMessage);
             const commitLink = document.createElement("a");
             commitLink.appendChild(document.createTextNode(data.commit.message.split("\n")[0]));

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -98,6 +98,7 @@ The following links will direct you to Google Drive folders. Please right-click 
     {
       const nightlyBuilds = document.getElementById("nightly-builds");
       const nightlyLoading = document.createElement("blockquote");
+      nightlyLoading.id = "nightly-loading";
       nightlyLoading.appendChild(document.createTextNode("Loading\u2026"));
       nightlyBuilds.parentNode.insertBefore(nightlyLoading, nightlyBuilds);
     }

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -51,7 +51,7 @@ a certain build is not available for your operating system, please check the pre
 
 <noscript id="build-dirs">
 <h2>Build Directories</h2>
-The following links will direct you to Google Drive folders. Please right-click on a file listed and select <code>Download</code>. The naming format is <code>pencil2d-OS-buildnumber-year-month-day</code>.
+<p>The following links will direct you to Google Drive folders. Please right-click on a file listed and select <code>Download</code>. The naming format is <code>pencil2d-OS-buildnumber-year-month-day</code>.</p>
 
 <table>
   <thead>

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -49,10 +49,37 @@ a certain build is not available for your operating system, please check the pre
 }
 </style>
 
+<noscript>
+<div id="build-dirs">
+<h2>Build Directories</h2>
+The following links will direct you to Google Drive folders. Please right-click on a file listed and select <code>Download</code>. The naming format is <code>pencil2d-OS-buildnumber-year-month-day</code>.
+
+<table>
+  <thead>
+    <tr>
+      <th style="text-align: center">Windows (64-bit)</th>
+      <th style="text-align: center">Windows (32-bit)</th>
+      <th style="text-align: center">macOS</th>
+      <th style="text-align: center">Linux (64-bit)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CSVlqc3JNQV9hVGs?resourcekey=0-mfeDpkYVm70KrOvKYM7UVw&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CcUEwS1R0WFhwM0E?resourcekey=0-7hr0hkLkSBVdEkaeb-okdg&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CeVpTY294cXdLZ2c?resourcekey=0-OH02kleYDbtzlw3UbxFMZA&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CcU1WOFpCOFBvVXc?resourcekey=0-2L-INjRPsn2ANX4MZIGU0Q&usp=sharing">Download</a></td>
+    </tr>
+  </tbody>
+</table>
+</div>
+</noscript>
+
 > Loading...
 {:#nightly-loading}
 
 <ol id="nightly-builds"></ol>
+
 <script>
   "use strict";
   (function() {
@@ -65,7 +92,10 @@ a certain build is not available for your operating system, please check the pre
     }
 
     function showError() {
-      document.getElementById("nightly-loading").textContent = "Unable to retrieve Nightly Builds. Please try again later.";
+      const nightlyLoading = document.getElementById("nightly-loading");
+      nightlyLoading.textContent = "Unable to retrieve Nightly Builds. Please try again later.";
+      const buildDirs = document.getElementById("build-dirs");
+      nightlyLoading.appendChild(buildDirs);
     }
 
     Promise.all([
@@ -151,7 +181,7 @@ a certain build is not available for your operating system, please check the pre
         // ...with the download links...
         const downloadList = document.createElement("li");
         let text = "Download for ";
-        for (let [os, osName] of [["win32", "Windows (32-bit)"], ["win64", "Windows (64-bit)"], ["macos", "macOS"], ["linux", "Linux"]]) {
+        for (let [os, osName] of [["win32", "Windows (32-bit)"], ["win64", "Windows (64-bit)"], ["macos", "macOS"], ["linux", "Linux (64-bit)"]]) {
           if (os in data === false) {
             continue; // No download for this OS
           }

--- a/download/nightly/index.md
+++ b/download/nightly/index.md
@@ -93,7 +93,7 @@ The following links will direct you to Google Drive folders. Please right-click 
       buildDirs.innerHTML = document.getElementById("build-dirs").innerHTML;
       nightlyLoading.parentNode.insertBefore(buildDirs, nightlyLoading);
     }
-    
+
     // Add loading message
     {
       const nightlyBuilds = document.getElementById("nightly-builds");
@@ -166,7 +166,8 @@ The following links will direct you to Google Drive folders. Please right-click 
         if ("commit" in data) {
           // Build summary - timestamp + (linked) commit message
           const timestamp = new Date(data.commit.timestamp);
-          const dateMessage = document.createTextNode(timestamp.toLocaleString(undefined, {"dateStyle": "medium"}) + " \u2013 ");
+          const dateMessage = document.createElement("span")
+          dateMessage.textContent = timestamp.toLocaleString(undefined, {"dateStyle": "medium"}) + " \u2013 ";
           dateMessage.title = timestamp.toLocaleString(undefined, {"dateStyle": "long", "timeStyle": "long"});
           summary.appendChild(dateMessage);
           const commitLink = document.createElement("a");

--- a/download/nightly/latest.md
+++ b/download/nightly/latest.md
@@ -1,0 +1,138 @@
+---
+layout: page
+title: Nightly Builds
+tagline: Download bleeding edge builds of Pencil2D
+comments: false
+fetch-limit: 100
+nightly-repo: pencil2d/pencil
+nightly-workflow: ci.yml
+drive-api-key: AIzaSyD2z_aPwUD5HFRHUtFKihgoEWv3nZnzsik
+windows-x86-parent: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E
+windows-x86-64-parent: 0BxdcdOiOmg-CSVlqc3JNQV9hVGs
+macos-parent: 0BxdcdOiOmg-CeVpTY294cXdLZ2c
+linux-parent: 0BxdcdOiOmg-CcU1WOFpCOFBvVXc
+resource-keys: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E/0-7hr0hkLkSBVdEkaeb-okdg,0BxdcdOiOmg-CSVlqc3JNQV9hVGs/0-mfeDpkYVm70KrOvKYM7UVw,0BxdcdOiOmg-CeVpTY294cXdLZ2c/0-OH02kleYDbtzlw3UbxFMZA,0BxdcdOiOmg-CcU1WOFpCOFBvVXc/0-2L-INjRPsn2ANX4MZIGU0Q
+---
+
+<noscript id="build-dirs">
+<h2>Build Directories</h2>
+The following links will direct you to Google Drive folders. Please right-click on a file listed and select <code>Download</code>. The naming format is <code>pencil2d-OS-buildnumber-year-month-day</code>.
+
+<table>
+  <thead>
+    <tr>
+      <th style="text-align: center">Windows (64-bit)</th>
+      <th style="text-align: center">Windows (32-bit)</th>
+      <th style="text-align: center">macOS</th>
+      <th style="text-align: center">Linux (64-bit)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CSVlqc3JNQV9hVGs?resourcekey=0-mfeDpkYVm70KrOvKYM7UVw&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CcUEwS1R0WFhwM0E?resourcekey=0-7hr0hkLkSBVdEkaeb-okdg&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CeVpTY294cXdLZ2c?resourcekey=0-OH02kleYDbtzlw3UbxFMZA&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CcU1WOFpCOFBvVXc?resourcekey=0-2L-INjRPsn2ANX4MZIGU0Q&usp=sharing">Download</a></td>
+    </tr>
+  </tbody>
+</table>
+</noscript>
+
+<ol id="nightly-builds"></ol>
+
+<script>
+  "use strict";
+  (function() {
+    function fetchGoogleDriveFiles(parentId) {
+      return fetch(`https://content.googleapis.com/drive/v3/files?q=%22${parentId}%22%20in%20parents&fields=files(originalFilename,webContentLink)&pageSize={{page.fetch-limit}}&key={{page.drive-api-key}}`, {
+        headers: {
+          "X-Goog-Drive-Resource-Keys": "{{page.resource-keys}}"
+        }
+      })
+    }
+
+    function showError() {
+      const nightlyLoading = document.getElementById("nightly-loading");
+      nightlyLoading.textContent = "Unable to retrieve the latest Nightly Build. Please try again later.";
+      const buildDirs = document.createElement("div");
+      buildDirs.innerHTML = document.getElementById("build-dirs").innerHTML;
+      nightlyLoading.parentNode.insertBefore(buildDirs, nightlyLoading);
+    }
+    
+    // Add loading message
+    {
+      const nightlyBuilds = document.getElementById("nightly-builds");
+      const nightlyLoading = document.createElement("blockquote");
+      nightlyLoading.id = "nightly-loading";
+      nightlyLoading.appendChild(document.createTextNode("Redirecting, please wait\u2026"));
+      nightlyBuilds.parentNode.insertBefore(nightlyLoading, nightlyBuilds);
+    }
+    
+    let os, arch = 64;
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has("os")) {
+      switch(urlParams.get("os").toLowerCase()) {
+      case "windows":
+      case "linux":
+        arch = Number(urlParams.get("arch")) || arch;
+      case "macos":
+        os = urlParams.get("os").toLowerCase();
+        break;
+      default:
+        showError();
+        return;
+      }
+    } else {
+      showError();
+      return;
+    }
+    
+    const driveMap = {
+      "windows": { 32: "{{page.windows-x86-parent}}", 64: "{{page.windows-x86-64-parent}}" },
+      "linux": { 64: "{{page.linux-parent}}" },
+      "macos": { 64: "{{page.macos-parent}}" }
+    }
+    
+    if ((os in driveMap && arch in driveMap[os]) === false) {
+      showError();
+      return;
+    }
+
+    fetchGoogleDriveFiles(driveMap[os][arch]).then(response => response.json())
+    .then((folder) => {
+      if ("message" in folder) {
+        // Messages are bad news, it means we got an error
+        showError();
+        return;
+      }
+      
+      let maxRunNumber = 0, maxRun = null;
+      for (let file of folder.files) {
+        const match = file.originalFilename.match(/^pencil2d-\w+-(\d+)-\d{4}-\d{2}-\d{2}.(zip|AppImage)$/);
+        if (match === null) {
+          // File name didn't match, don't know what to do with it
+          continue;
+        }
+        const runNumber = match[1];
+        if (runNumber > maxRunNumber) {
+          maxRunNumber = runNumber;
+          maxRun = file;
+        }
+      }
+      
+      if (maxRunNumber > 0) {
+        window.location.href = maxRun.webContentLink;
+        
+        const nightlyLoading = document.getElementById("nightly-loading");
+        nightlyLoading.textContent = "Thank you for your patience. If you are not redirected shortly, please click ";
+        const manualRedirect = document.createElement("a");
+        manualRedirect.href = maxRun.webContentLink;
+        manualRedirect.textContent = "here";
+        nightlyLoading.appendChild(manualRedirect);
+      } else {
+        showError();
+      }
+    })
+    .catch(showError);
+  })();
+</script>

--- a/download/nightly/latest.md
+++ b/download/nightly/latest.md
@@ -16,7 +16,7 @@ resource-keys: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E/0-7hr0hkLkSBVdEkaeb-okdg,0BxdcdOiOmg
 
 <noscript id="build-dirs">
 <h2>Build Directories</h2>
-The following links will direct you to Google Drive folders. Please right-click on a file listed and select <code>Download</code>. The naming format is <code>pencil2d-OS-buildnumber-year-month-day</code>.
+<p>The following links will direct you to Google Drive folders. Please right-click on a file listed and select <code>Download</code>. The naming format is <code>pencil2d-OS-buildnumber-year-month-day</code>.</p>
 
 <table>
   <thead>
@@ -58,7 +58,7 @@ The following links will direct you to Google Drive folders. Please right-click 
       buildDirs.innerHTML = document.getElementById("build-dirs").innerHTML;
       nightlyLoading.parentNode.insertBefore(buildDirs, nightlyLoading);
     }
-    
+
     // Add loading message
     {
       const nightlyBuilds = document.getElementById("nightly-builds");
@@ -67,7 +67,7 @@ The following links will direct you to Google Drive folders. Please right-click 
       nightlyLoading.appendChild(document.createTextNode("Redirecting, please wait\u2026"));
       nightlyBuilds.parentNode.insertBefore(nightlyLoading, nightlyBuilds);
     }
-    
+
     let os, arch = 64;
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.has("os")) {
@@ -86,13 +86,13 @@ The following links will direct you to Google Drive folders. Please right-click 
       showError();
       return;
     }
-    
+
     const driveMap = {
       "windows": { 32: "{{page.windows-x86-parent}}", 64: "{{page.windows-x86-64-parent}}" },
       "linux": { 64: "{{page.linux-parent}}" },
       "macos": { 64: "{{page.macos-parent}}" }
     }
-    
+
     if ((os in driveMap && arch in driveMap[os]) === false) {
       showError();
       return;
@@ -105,7 +105,7 @@ The following links will direct you to Google Drive folders. Please right-click 
         showError();
         return;
       }
-      
+
       let maxRunNumber = 0, maxRun = null;
       for (let file of folder.files) {
         const match = file.originalFilename.match(/^pencil2d-\w+-(\d+)-\d{4}-\d{2}-\d{2}.(zip|AppImage)$/);
@@ -119,10 +119,10 @@ The following links will direct you to Google Drive folders. Please right-click 
           maxRun = file;
         }
       }
-      
+
       if (maxRunNumber > 0) {
         window.location.href = maxRun.webContentLink;
-        
+
         const nightlyLoading = document.getElementById("nightly-loading");
         nightlyLoading.textContent = "Thank you for your patience. If you are not redirected shortly, please click ";
         const manualRedirect = document.createElement("a");

--- a/download/nightly/latest.md
+++ b/download/nightly/latest.md
@@ -8,10 +8,13 @@ nightly-repo: pencil2d/pencil
 nightly-workflow: ci.yml
 drive-api-key: AIzaSyD2z_aPwUD5HFRHUtFKihgoEWv3nZnzsik
 windows-x86-parent: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E
+windows-x86-resource-key: 0-7hr0hkLkSBVdEkaeb-okdg
 windows-x86-64-parent: 0BxdcdOiOmg-CSVlqc3JNQV9hVGs
+windows-x86-64-resource-key: 0-mfeDpkYVm70KrOvKYM7UVw
 macos-parent: 0BxdcdOiOmg-CeVpTY294cXdLZ2c
+macos-resource-key: 0-OH02kleYDbtzlw3UbxFMZA
 linux-parent: 0BxdcdOiOmg-CcU1WOFpCOFBvVXc
-resource-keys: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E/0-7hr0hkLkSBVdEkaeb-okdg,0BxdcdOiOmg-CSVlqc3JNQV9hVGs/0-mfeDpkYVm70KrOvKYM7UVw,0BxdcdOiOmg-CeVpTY294cXdLZ2c/0-OH02kleYDbtzlw3UbxFMZA,0BxdcdOiOmg-CcU1WOFpCOFBvVXc/0-2L-INjRPsn2ANX4MZIGU0Q
+linux-resource-key: 0-2L-INjRPsn2ANX4MZIGU0Q
 ---
 
 <noscript id="build-dirs">
@@ -29,10 +32,10 @@ resource-keys: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E/0-7hr0hkLkSBVdEkaeb-okdg,0BxdcdOiOmg
   </thead>
   <tbody>
     <tr>
-      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CSVlqc3JNQV9hVGs?resourcekey=0-mfeDpkYVm70KrOvKYM7UVw&usp=sharing">Download</a></td>
-      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CcUEwS1R0WFhwM0E?resourcekey=0-7hr0hkLkSBVdEkaeb-okdg&usp=sharing">Download</a></td>
-      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CeVpTY294cXdLZ2c?resourcekey=0-OH02kleYDbtzlw3UbxFMZA&usp=sharing">Download</a></td>
-      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/0BxdcdOiOmg-CcU1WOFpCOFBvVXc?resourcekey=0-2L-INjRPsn2ANX4MZIGU0Q&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/{{page.windows-x86-64-parent}}?resourcekey={{page.windows-x86-64-resource-key}}&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/{{page.windows-x86-parent}}?resourcekey={{page.windows-x86-64-resource-key}}&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/{{page.macos-parent}}?resourcekey={{page.macos-resource-key}}&usp=sharing">Download</a></td>
+      <td style="text-align: center"><a href="https://drive.google.com/drive/folders/{{page.linux-parent}}?resourcekey={{page.linux-resource-key}}&usp=sharing">Download</a></td>
     </tr>
   </tbody>
 </table>
@@ -40,23 +43,24 @@ resource-keys: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E/0-7hr0hkLkSBVdEkaeb-okdg,0BxdcdOiOmg
 
 <ol id="nightly-builds"></ol>
 
+<script src="nightly_fetch.js"></script>
 <script>
   "use strict";
   (function() {
-    function fetchGoogleDriveFiles(parentId) {
-      return fetch(`https://content.googleapis.com/drive/v3/files?q=%22${parentId}%22%20in%20parents&fields=files(originalFilename,webContentLink)&pageSize={{page.fetch-limit}}&key={{page.drive-api-key}}`, {
-        headers: {
-          "X-Goog-Drive-Resource-Keys": "{{page.resource-keys}}"
-        }
-      })
-    }
-
-    function showError() {
+    function displayFallback() {
       const nightlyLoading = document.getElementById("nightly-loading");
-      nightlyLoading.textContent = "Unable to retrieve the latest Nightly Build. Please try again later.";
+      nightlyLoading.style.display = "none";
       const buildDirs = document.createElement("div");
       buildDirs.innerHTML = document.getElementById("build-dirs").innerHTML;
-      nightlyLoading.parentNode.insertBefore(buildDirs, nightlyLoading);
+      nightlyLoading.parentNode.insertBefore(buildDirs, nightlyLoading.nextSibling);
+    }
+
+    function showError(message) {
+      displayFallback();
+      const nightlyLoading = document.getElementById("nightly-loading");
+      const errorMessage = document.createElement("blockquote");
+      errorMessage.textContent = message;
+      nightlyLoading.parentNode.insertBefore(errorMessage, nightlyLoading.nextSibling);
     }
 
     // Add loading message
@@ -71,68 +75,85 @@ resource-keys: 0BxdcdOiOmg-CcUEwS1R0WFhwM0E/0-7hr0hkLkSBVdEkaeb-okdg,0BxdcdOiOmg
     let os, arch = 64;
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.has("os")) {
-      switch(urlParams.get("os").toLowerCase()) {
+      const osParam = urlParams.get("os").toLowerCase();
+      switch(osParam) {
       case "windows":
       case "linux":
         arch = Number(urlParams.get("arch")) || arch;
       case "macos":
-        os = urlParams.get("os").toLowerCase();
+        os = osParam;
         break;
       default:
-        showError();
+        showError(`There are no nightly builds for the operating system "${osParam}". Supported operating systems are: "windows", "macos", "linux".`);
         return;
       }
     } else {
-      showError();
+      console.error("Invalid search params. Must specify os parameter.");
+      displayFallback();
       return;
     }
 
     const driveMap = {
-      "windows": { 32: "{{page.windows-x86-parent}}", 64: "{{page.windows-x86-64-parent}}" },
-      "linux": { 64: "{{page.linux-parent}}" },
-      "macos": { 64: "{{page.macos-parent}}" }
+      "windows": {
+        32: { "parentId": "{{page.windows-x86-parent}}", "resourceId": "{{page.windows-x86-resource-key}}" },
+        64: { "parentId": "{{page.windows-x86-64-parent}}", "resourceId": "{{page.windows-x86-64-resource-key}}" }
+      },
+      "linux": { 64: { "parentId": "{{page.linux-parent}}", "resourceId": "{{page.linux-resource-key}}" } },
+      "macos": { 64: { "parentId": "{{page.macos-parent}}", "resourceId": "{{page.macos-resource-key}}" } }
     }
 
-    if ((os in driveMap && arch in driveMap[os]) === false) {
-      showError();
+    if (!(os in driveMap)) {
+      showError(`There are no nightly builds for the operating system "${osParam}". Supported operating systems are: "windows", "macos", "linux".`);
+      return;
+    }
+    if (!(arch in driveMap[os])) {
+      showError(`There are no nightly builds for the ${arch}-bit architecture of ${os}. Supported architectures for ${os} are: ` + Object.keys(driveMap[os]).map(arch => arch + "-bit").join(", "));
       return;
     }
 
-    fetchGoogleDriveFiles(driveMap[os][arch]).then(response => response.json())
-    .then((folder) => {
-      if ("message" in folder) {
-        // Messages are bad news, it means we got an error
-        showError();
+    const fetcher = new NightlyBuildFetcher("{{page.drive-api-key}}", {{page.fetch-limit}});
+    fetcher.addGDriveResource(driveMap[os][arch]["parentId"], driveMap[os][arch]["resourceId"], "result");
+
+    fetcher.fetchAll().then(fetch_results => {
+      if ("result" in fetch_results) {
+        let folder = fetch_results["result"];
+        let maxRunNumber = 0, maxRun = null;
+        console.log(folder);
+        for (let file of folder.files) {
+          const match = file.originalFilename.match(/^pencil2d-\w+-(\d+)-\d{4}-\d{2}-\d{2}.(zip|AppImage)$/);
+          if (match === null) {
+            // File name didn't match, don't know what to do with it
+            continue;
+          }
+          const runNumber = match[1];
+          if (runNumber > maxRunNumber) {
+            maxRunNumber = runNumber;
+            maxRun = file;
+          }
+        }
+
+        if (maxRunNumber > 0) {
+          window.location.href = maxRun.webContentLink;
+
+          const nightlyLoading = document.getElementById("nightly-loading");
+          nightlyLoading.textContent = "Thank you for your patience. If you are not redirected shortly, please click ";
+          const manualRedirect = document.createElement("a");
+          manualRedirect.href = maxRun.webContentLink;
+          manualRedirect.textContent = "here";
+          nightlyLoading.appendChild(manualRedirect);
+        } else {
+          showError("No builds were found for the specified os and architecture.");
+          return;
+        }
+
+      }
+      else {
+        showError("There was an error automatically fetching the build data.");
         return;
       }
-
-      let maxRunNumber = 0, maxRun = null;
-      for (let file of folder.files) {
-        const match = file.originalFilename.match(/^pencil2d-\w+-(\d+)-\d{4}-\d{2}-\d{2}.(zip|AppImage)$/);
-        if (match === null) {
-          // File name didn't match, don't know what to do with it
-          continue;
-        }
-        const runNumber = match[1];
-        if (runNumber > maxRunNumber) {
-          maxRunNumber = runNumber;
-          maxRun = file;
-        }
-      }
-
-      if (maxRunNumber > 0) {
-        window.location.href = maxRun.webContentLink;
-
-        const nightlyLoading = document.getElementById("nightly-loading");
-        nightlyLoading.textContent = "Thank you for your patience. If you are not redirected shortly, please click ";
-        const manualRedirect = document.createElement("a");
-        manualRedirect.href = maxRun.webContentLink;
-        manualRedirect.textContent = "here";
-        nightlyLoading.appendChild(manualRedirect);
-      } else {
-        showError();
-      }
-    })
-    .catch(showError);
+    }).catch(error => {
+      console.error(error);
+      showError("There was an error automatically fetching the build data.");
+    });
   })();
 </script>

--- a/download/nightly/nightly_fetch.js
+++ b/download/nightly/nightly_fetch.js
@@ -1,0 +1,74 @@
+"use strict";
+class NightlyBuildFetcher {
+  constructor(gDriveKey, fetchLimit) {
+    this.fetchLimit = fetchLimit;
+    this.gDriveKey = gDriveKey;
+    this.resources = [];
+  }
+
+  addGDriveResource(parentId, resourceId, label) {
+    this.resources.push({
+      "label": label,
+      "type": "googleDrive",
+      "parentId": parentId,
+      "resourceId": resourceId
+    });
+  }
+
+  addGithubActionsResource(repo, workflow, label) {
+    this.resources.push({
+      "label": label,
+      "type": "githubActions",
+      "repo": repo,
+      "workflow": workflow
+    });
+  }
+
+  fetchAll() {
+    function fetchGithubRuns(resource) {
+      return fetch(`https://api.github.com/repos/${resource.repo}/actions/workflows/${resource.workflow}/runs?per_page=${this.fetchLimit}`, {
+        headers: {
+          "Accept": "application/vnd.github.v3+json"
+        }
+      }).then(response => {
+        if (response.ok)
+          return response.json();
+        else
+          throw new Error(response.statusText);
+      });
+    }
+
+    function fetchGoogleDriveFiles(resource) {
+      return fetch(`https://content.googleapis.com/drive/v3/files?q=%22${resource.parentId}%22%20in%20parents&fields=files(originalFilename,webContentLink)&pageSize=${this.fetchLimit}&key=${this.gDriveKey}`, {
+        headers: {
+          "X-Goog-Drive-Resource-Keys": `${resource.parentId}/${resource.resourceId}`
+        }
+      }).then(response => {
+        if (response.ok)
+          return response.json();
+        else
+          return Promise.reject(new Error(response.statusText));
+      });
+    }
+
+    const fetchMap = {
+      "githubActions": fetchGithubRuns,
+      "googleDrive": fetchGoogleDriveFiles
+    };
+
+    let promises = [];
+
+    this.resources.forEach(resource => {
+      promises.push(fetchMap[resource["type"]].call(this, resource));
+    });
+
+    return Promise.allSettled(promises).then(responses => {
+      let results = {};
+      responses.forEach((response, index) => {
+        if (response.status == "fulfilled")
+          results[this.resources[index]["label"]] = response.value;
+      });
+      return results;
+    });
+  }
+}


### PR DESCRIPTION
Here are some things I think would improve your nightly build's page. Sorry for pushing them directly to your fork initially, I did not realize I had it tracking the wrong remote initially.

There are a lot of miscellaneous changes here, but the big ones are:
- Providing links to the drive folders when there's an error or javascript is disabled
- Use CSS to add ellipses if necessary rather than hardcoding a maximum summary length. This should work better with smaller windows and has the benefit of being able to 
- Use a more human-readable date format. I also hid the time component because for the most part there should only be one build per day due to overriding.
- Create a new page which will automatically redirect to the latest download for a particular os. This was a bit of a feature creep I admit, but it will come in really handy when we want to link a build for support purposes, and I was able to reuse your code to do most of it.
- Fix some of the "Unable to retrieve information" issues. Not sure why, but for some reason those builds are filtered out when using the branch url parameter. I am a bit worried that the page limit of 100 may not be enough now if there are lots of PR builds, but this is not a problem currently.